### PR TITLE
"典"にアクセントとして反転、ついでに枠線を追加

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -174,6 +174,16 @@ strong, b {
 em, i {
   font-style: italic; }
 
+span.rev {
+  background-color: #000;
+  color: #fff; }
+
+span.box {
+  padding: 1px;
+  border-color: #000;
+  border-style: solid;
+  border-width: 2px 0 2px 2px; }
+
 p {
   margin: 0 0 2em 0; }
 

--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -64,6 +64,18 @@
 		font-style: italic;
 	}
 
+	span.rev {
+		background-color: _palette(fg-bold);
+		color: _palette(bg);
+	}
+
+	span.box {
+		padding: 1px;
+		border-color: _palette(fg-bold);
+		border-style: solid;
+		border-width: _size(border-width) 0 _size(border-width) _size(border-width);
+	}
+
 	p {
 		margin: 0 0 _size(element-margin) 0;
 	}

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 	<body>
 		<!-- Header -->
 		<header id="header">
-			<h1>技術書典</h1>
+			<h1><span class="box">技</span><span class="box">術</span><span class="box">書</span><span class="rev box">典</span></span></h1>
 			<p>今日から著者。 技術書オンリーイベント開催決定！</p>
 		</header>
 


### PR DESCRIPTION
そのまま「技術書典」と読まれるとイベントぽく見えなかったので、「典」を反転させてアクセントを付けてみるのはどうでしょうか（反転するだけだと浮くので枠線も追加しています。カッチリ感が出るけどちょっとカタいかも？）。
### before

![2016-03-11 22 42 31](https://cloud.githubusercontent.com/assets/10401/13703636/ced2a938-e7da-11e5-853f-6c2b6fdba423.png)
### after

![2016-03-11 22 42 35](https://cloud.githubusercontent.com/assets/10401/13703656/dc46d508-e7da-11e5-9505-1c30c5f63df7.png)
