### PR TITLE
表示領域の横幅が狭い時に背景画像が切れていたのを修正

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -124,7 +124,8 @@ body {
 
 @media screen and (max-width: 980px) {
   #bg img {
-    max-height: none; }
+    left: 0;
+    max-width: none; }
   #bg .bg-image--under-medium {
     visibility: visible; }
   #bg .bg-image--upper-medium {

--- a/assets/sass/base/_bg.scss
+++ b/assets/sass/base/_bg.scss
@@ -41,7 +41,8 @@
 	@include breakpoint(medium) {
 		#bg {
 			img {
-				max-height: none;
+				left: 0;
+				max-width: none;
 			}
 
 			.bg-image--under-medium {


### PR DESCRIPTION
余計な黒枠が画像内にありますが気にしないでください
## before

<img width="375" alt="2016-03-12 00 34 37" src="https://cloud.githubusercontent.com/assets/430267/13707064/3fa9cd48-e7eb-11e5-8483-38d2a049e264.png">
## after

<img width="372" alt="2016-03-12 00 35 14" src="https://cloud.githubusercontent.com/assets/430267/13707065/3faa0b3c-e7eb-11e5-9f6d-a54ab65e82fb.png">
