### PR TITLE
protocolを設定する際はコロン(:)は不要らしい

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 			// Force HTTPS
 			var host = "techbookfest.github.io", protocol = "https:";
 			if (location.host === host && location.protocol !== protocol) {
-				location.protocol = protocol;
+				location.protocol = protocol.slice(0, -1); // Remove ":"
 			}
 		})();
 		</script>


### PR DESCRIPTION
`https:`ではなく`https`と設定するのが正しいようです。
これまでコロン付きでも各ブラウザで動いてたんですが、Fx45ではエラーになっています。

FYR https://twitter.com/mstssk/status/708972050891681792
